### PR TITLE
Add note about bandwidth restrictions

### DIFF
--- a/remote-access/web-server/README.md
+++ b/remote-access/web-server/README.md
@@ -6,3 +6,5 @@ Various web servers are available, with different advantages for usage:
 
 - [Apache](apache.md)
 - [NGINX](nginx.md)
+
+If running a global web server, check the bandwidth limitations for your ISP (internet service provider).


### PR DESCRIPTION
Often, internet service providers have limits to how much bandwidth customers can use if running a global internet server.